### PR TITLE
Fixed variable names

### DIFF
--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -79,7 +79,7 @@ The connect method will be implemented later. To see a full example, navigate to
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   // Initialize and start the proxy
-  [[ProxyManager sharedManager] start];
+  [[ProxyManager sharedManager] connect];
 }
 
 @end
@@ -90,7 +90,7 @@ The connect method will be implemented later. To see a full example, navigate to
 class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
     // Initialize and start the proxy
-    ProxyManager.shared.start()
+    ProxyManager.sharedManager.connect()
 
     return true
   }
@@ -156,7 +156,7 @@ NS_ASSUME_NONNULL_END
 ```swift
 class ProxyManager: NSObject {
   // Manager
-  fileprivate let sdlManager: SDLManager
+  fileprivate var sdlManager: SDLManager!
     
   // Singleton
   static let sharedManager = ProxyManager()

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -329,7 +329,7 @@ The manager should be started as soon as possible in your application's lifecycl
 
 #### Swift
 ```swift
-sdlManager.start(readyHandler { (success, error) in
+sdlManager.start { (success, error) in
     if success {
       // Your app has successfully connected with the SDL Core.
     }


### PR DESCRIPTION
Fixes issue #54, #55

This pull request **fixes existing content**.

## Summary of Changes
Fixes made to **Getting Started > Integration Basics** so the same variable and method names are being used throughout the guide.
- `shared` is now `sharedManager` and  `start()` is now `connect()` in the `AppDelegate` example. They now match the variable and method names used in the large example at the end of the guide.
- Fixed the two `sdlManager` declarations so they match.
