### PR TITLE
Fixed CocoaPods library name

### DIFF
--- a/docs/Getting Started/Installation/index.md
+++ b/docs/Getting Started/Installation/index.md
@@ -21,7 +21,7 @@ pod init
 6. In the **Podfile**, add the following text. This tells CocoaPods to install SDL SDK for iOS.
 ```
 target ‘<#Your Project Name#>’ do
-    pod ‘SmartDeviceLink-iOS’, ‘~> <#SDL Version#>’
+    pod ‘SmartDeviceLink’, ‘~> <#SDL Version#>’
 end
 ```
 !!! NOTE


### PR DESCRIPTION
Fixes #63 

This pull request **fixes existing content]**.

## Summary of Changes
Fixed deprecated library name in the code example for installing SDL_iOS via CocoaPods.