### PR TITLE
Added information about RPC permissions

### DIFF
--- a/config.json
+++ b/config.json
@@ -25,6 +25,9 @@
                   "name": "Adapting to the Head Unit Language"
               },
               {
+              	 "name": "Understanding Permissions"
+              },
+              {
                   "name": "Batch Sending RPCs"
               }
             ]
@@ -54,9 +57,6 @@
         },
         {
             "name": "Uploading Files and Graphics"
-        },
-        {
-            "name": "Knowing the In-Car UI Status"
         },
         {
             "name": "Adding the Lock Screen"

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -4,8 +4,10 @@ SmartDeviceLink works by sending remote procedure calls (RPCs) back and forth be
 
 ### Set Up a Proxy Manager Class
 You will need a class that manages the RPCs sent back and forth between your app and SDL Core. Since there should be only one active connection to the SDL Core, you may wish to implement this proxy class using the singleton pattern.
+
 ##### Objective-C
 ###### ProxyManager.h
+
 ```objc
 #import <Foundation/Foundation.h>
 
@@ -19,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 ```
+
 ###### ProxyManager.m
 ```objc
 #import "ProxyManager.h"
@@ -80,6 +83,7 @@ The connect method will be implemented later. To see a full example, navigate to
 
 @end
 ```
+
 ##### Swift
 ```swift
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -94,10 +98,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 ### Import the SDL Library
 At the top of the *ProxyManager* class, import the SDL for iOS library.
+
 ##### Objective-C
 ```objc
 #import <SmartDeviceLink/SmartDeviceLink.h>
 ```
+
 ##### Swift
 ```swift
 import SmartDeviceLink
@@ -105,6 +111,7 @@ import SmartDeviceLink
 
 ### Create the SDL Manager
 The `SDLManager` is the main class of SmartDeviceLink. It will handle setting up the initial connection with the head unit. It will also help you upload images and send RPCs.
+
 ##### Objective-C
 ```objc
 #import "ProxyManager.h"
@@ -143,6 +150,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 ```
+
 ##### Swift
 ```swift
 class ProxyManager: NSObject {
@@ -164,40 +172,42 @@ In order to instantiate the `SDLManager` class, you must first configure an `SDL
 #### Network Connection Type
 There are two different ways to connect your app to a SDL Core: with a TCP (Wi-Fi) network connection or with an iAP (USB / Bluetooth) network connection. Use TCP for debugging and use iAP for production level apps.
 
-**iAP**
-##### Objective-C
+##### iAP
+###### Objective-C
 ```objc
 SDLLifecycleConfiguration* lifecycleConfiguration = [SDLLifecycleConfiguration defaultConfigurationWithAppName:@"<#App Name#>" appId:@"<#App Id#>"];
 ```
-##### Swift
+###### Swift
 ```swift
 let lifecycleConfiguration = SDLLifecycleConfiguration(appName:"<#App Name#>", appId: "<#App Id#>")
 ```
 
-**TCP**
-##### Objective-C
+##### TCP
+###### Objective-C
 ```objc
 SDLLifecycleConfiguration* lifecycleConfiguration = [SDLLifecycleConfiguration debugConfigurationWithAppName:@"<#App Name#>" appId:@"<#App Id#>" ipAddress:@"<#IP Address#>" port:<#Port#>];
 ```
-##### Swift
+###### Swift
 ```swift
 let lifecycleConfiguration = SDLLifecycleConfiguration(appName: "<#App Name#>", appId: "<#App Id#>", ipAddress: "<#IP Address#>", port: <#Port#>))
 ```  
 
 !!! NOTE
-If you are using an emulator, the IP address is your computer or virtual machine’s IP address, and the port number is usually 12345. If these values are not correct, or emulator is not running, your app with not run, as TCP connections occur on the main thread.
+If you are using an emulator, the IP address is your computer or virtual machine’s IP address, and the port number is usually **12345**. If these values are not correct, or emulator is not running, your app with not run, as TCP connections occur on the main thread.
 !!!
 
 !!! IMPORTANT
 If you are using a head unit or TDK, and are using the [Relay app](Developer Tools/Relay) for debugging, the IP address and port number should be set to the same IP address and port number as the app. This information appears in the Relay app once the server is turned on in the app. Also be sure that the device is on the same network as your app.
 !!!
 
-### 2. Short app name (optional)
+### 2. Short App Name (optional)
 This is a shortened version of your app name that is substituted when the full app name will not be visible due to character count constraints. You will want to make this as short as possible.
+
 ##### Objective-C
 ```objc
 lifecycleConfiguration.shortAppName = @"<#Shortened App Name#>";
 ```
+
 ##### Swift
 ```swift
 lifecycleConfiguration.shortAppName = "<#Shortened App Name#>"
@@ -205,6 +215,7 @@ lifecycleConfiguration.shortAppName = "<#Shortened App Name#>"
 
 ### 3. App Icon
 This is a custom icon for your application. Please refer to [Uploading Files and Graphics](Uploading Files and Graphics) for icon sizes.
+
 ##### Objective-C
 ```objc
 UIImage* appImage = [UIImage imageNamed:@"<#AppIcon Name#>"];
@@ -213,6 +224,7 @@ if (appImage) {
   lifecycleConfiguration.appIcon = appIcon;  
 }
 ```
+
 ##### Swift
 ```swift
 if let appImage = UIImage(named: "<#AppIcon Name#>") {
@@ -237,6 +249,7 @@ Navigation and projection apps usually require special permissions and use video
 ```objc
 lifecycleConfiguration.appType = SDLAppHMITypeMedia;
 ```
+
 ##### Swift
 ```swift
 lifecycleConfiguration.appType = .media
@@ -248,10 +261,12 @@ A lock screen is used to prevent the user from interacting with the app on the s
 The SDL SDK can take care of the lock screen implementation for you, automatically using your app logo and the connected vehicle logo. If you do not want to use the default lock screen, you can implement your own custom lock screen.
 
 For more information, please refer to the [Adding the Lock Screen](Adding the Lock Screen) section, for this guide we will be using `SDLLockScreenConfiguration`'s basic `enabledConfiguration`.
+
 ##### Objective-C
 ```objc
 [SDLLockScreenConfiguration enabledConfiguration]
 ```
+
 ##### Swift
 ```swift
 SDLLockScreenConfiguration.enabled()
@@ -259,10 +274,12 @@ SDLLockScreenConfiguration.enabled()
 
 ### 6. Logging
 A logging configuration is used to define where and how often SDL will log. It will also allow you to set your own logging modules and filters.
+
 ##### Objective-C
 ```objc
 [SDLLogConfiguration defaultConfiguration]
 ```
+
 ##### Swift
 ```objc
 SDLLogConfiguration.default()
@@ -270,10 +287,12 @@ SDLLogConfiguration.default()
 
 ### 7. Set the Configuration
 The `SDLConfiguration` class is used to set the lifecycle, lock screen, logging, and optionally (dependent on if you are a Navigation or Projection app) streaming media configurations for the app. Use the lifecycle configuration settings above to instantiate a `SDLConfiguration` instance.
+
 ##### Objective-C
 ```objc
 SDLConfiguration* configuration = [SDLConfiguration configurationWithLifecycle:lifecycleConfiguration lockScreen:[SDLLockScreenConfiguration enabledConfiguration] logging:[SDLLogConfiguration defaultConfiguration]];
 ```
+
 ##### Swift
 ```swift
 let configuration = SDLConfiguration(lifecycle: lifecycleConfiguration, lockScreen: .enabled(), logging: .default())
@@ -281,10 +300,12 @@ let configuration = SDLConfiguration(lifecycle: lifecycleConfiguration, lockScre
 
 ### 8. Create a SDLManager
 Now you can use the `SDLConfiguration` instance to instantiate the `SDLManager`.
+
 ##### Objective-C
 ```objc
 self.sdlManager = [[SDLManager alloc] initWithConfiguration:configuration delegate:self];
 ```
+
 ##### Swift
 ```swift
 sdlManager = SDLManager(configuration: configuration, delegate: self)
@@ -292,6 +313,7 @@ sdlManager = SDLManager(configuration: configuration, delegate: self)
 
 ### 9. Start the SDLManager
 The manager should be started as soon as possible in your application's lifecycle. We suggest doing this in the `didFinishLaunchingWithOptions()` method in your *AppDelegate* class. Once the manager has been initialized, it will immediately start watching for a connection with the remote system. The manager will passively search for a connection with a SDL Core during the entire lifespan of the app. If the manager detects a connection with a SDL Core, the `startWithReadyHandler` will be called.
+
 ##### Objective-C
 ```objc
 [self.sdlManager startWithReadyHandler:^(BOOL success, NSError * _Nullable error) {
@@ -300,6 +322,7 @@ The manager should be started as soon as possible in your application's lifecycl
   }
 }];
 ```
+
 ##### Swift
 ```swift
 sdlManager.start { (success, error) in
@@ -313,10 +336,11 @@ sdlManager.start { (success, error) in
 In production, your app will be watching for connections using iAP, which will not use any additional battery power than normal.  
 !!!  
 
-If the connection is successful, you can start sending RPCs to the SDL Core. However, some RPCs can only be sent when the HMI is in the FULL or LIMITED state. If the SDL Core's HMI is not ready to accept these RPCs, your requests will be ignored. If you want to make sure that the SDL Core will not ignore your RPCs, use the `SDLManagerDelegate` methods in the next section.
+If the connection is successful, you can start sending RPCs to the SDL Core. However, some RPCs can only be sent when the HMI is in the `FULL` or `LIMITED` state. If the SDL Core's HMI is not ready to accept these RPCs, your requests will be ignored. If you want to make sure that the SDL Core will not ignore your RPCs, use the `SDLManagerDelegate` methods in the next section.
 
 ### Example Implementation of a Proxy Class  
 The following code snippet has an example of setting up both a TCP and iAP connection.
+
 ##### Objective-C
 ###### ProxyManager.h
 ```objc
@@ -409,6 +433,7 @@ static NSString* const AppId = @"<#App Id#>";
 
 NS_ASSUME_NONNULL_END
 ```
+
 ##### Swift
 ```swift
 import SmartDeviceLink
@@ -474,7 +499,7 @@ The *ProxyManager* class should conform to the `SDLManagerDelegate` protocol. Th
 1. `managerDidDisconnect` This function is called when the proxy disconnects from the SDL Core. Do any cleanup you need to do in this function.
 1. `hmiLevel:didChangeToLevel:` This function is called when the HMI level changes for the app. The HMI level can be `FULL`, `LIMITED`, `BACKGROUND`, or `NONE`. It is important to note that most RPCs sent while the HMI is in `BACKGROUND` or `NONE` mode will be ignored by the SDL Core. For more information, please refer to [Understanding Permissions](Getting Started/Understanding Permissions).
 
-In addition there are three optional methods:
+In addition, there are three optional methods:
 
 1. `audioStreamingState:didChangeToState:` Called when the audio streaming state of this application changes on the remote system. For more information, please refer to [Understanding Permissions](Getting Started/Understanding Permissions).
 1. `systemContext:didChangeToContext:` Called when the system context (i.e. a menu is open, an alert is visible,  a voice recognition session is in progress) of this application changes on the remote system. For more information, please refer to [Understanding Permissions](Getting Started/Understanding Permissions).

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -500,17 +500,14 @@ extension ProxyManager: SDLManagerDelegate {
 ### Implement the SDL Manager Delegate
 The *ProxyManager* class should conform to the `SDLManagerDelegate` protocol. This means that the *ProxyManager* class must implement the following required methods:
 
-1. `managerDidDisconnect` This function is called only once, when the proxy disconnects from the SDL Core. Do any cleanup you need to do in this function.
-1. `hmiLevel:didChangeToLevel:` This function is called when the HMI level changes for the app. The HMI level can be `FULL`, `LIMITED`, `BACKGROUND`, or `NONE`. It is important to note that most RPCs sent while the HMI is in `BACKGROUND` or `NONE` mode will be ignored by the SDL Core.
+1. `managerDidDisconnect` This function is called when the proxy disconnects from the SDL Core. Do any cleanup you need to do in this function.
+1. `hmiLevel:didChangeToLevel:` This function is called when the HMI level changes for the app. The HMI level can be `FULL`, `LIMITED`, `BACKGROUND`, or `NONE`. It is important to note that most RPCs sent while the HMI is in `BACKGROUND` or `NONE` mode will be ignored by the SDL Core. For more information, please refer to [Understanding Permissions](Getting Started/Understanding Permissions).
 
 In addition there are three optional methods:
 
-1. `audioStreamingState:didChangeToState:` Called when the audio streaming state of this application changes on the remote system.
-1. `systemContext:didChangeToContext:` Called when the system context (i.e. a menu is open, an alert is visible,  a voice recognition session is in progress) of this application changes on the remote system.
+1. `audioStreamingState:didChangeToState:` Called when the audio streaming state of this application changes on the remote system. For more information, please refer to [Understanding Permissions](Getting Started/Understanding Permissions).
+1. `systemContext:didChangeToContext:` Called when the system context (i.e. a menu is open, an alert is visible,  a voice recognition session is in progress) of this application changes on the remote system. For more information, please refer to [Understanding Permissions](Getting Started/Understanding Permissions).
 1. `managerShouldUpdateLifecycleToLanguage:` Called when the head unit language does not match the `language` set in the `SDLLifecycleConfiguration` but does match a language included in `languagesSupported`. If desired, you can customize the `appName`, the `shortAppName`,  and `ttsName` for the head unit's current language. For more information about supporting more than one language in your app please refer to [Getting Started/Adapting to the Head Unit Language](Getting Started/Adapting to the Head Unit Language).
-
-### The Different HMI Levels:
-Please refer to [Knowing the In-Car UI Status](Knowing the In-Car UI Status) for information about HMI levels.
 
 ### Where to go from here
 You should now be able to connect to a head unit or emulator. From here, [learn about designing a user interface](Displaying Information/Designing a User Interface). For further details on connecting, see [Connecting to a SDL Core](Getting Started/Connecting to a SDL Core).

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -164,7 +164,7 @@ In order to instantiate the `SDLManager` class, you must first configure an `SDL
 #### Network Connection Type
 There are two different ways to connect your app to a SDL Core: with a TCP (Wi-Fi) network connection or with an iAP (USB / Bluetooth) network connection. Use TCP for debugging and use iAP for production level apps.
 
-#### iAP
+**iAP**
 ##### Objective-C
 ```objc
 SDLLifecycleConfiguration* lifecycleConfiguration = [SDLLifecycleConfiguration defaultConfigurationWithAppName:@"<#App Name#>" appId:@"<#App Id#>"];
@@ -174,7 +174,7 @@ SDLLifecycleConfiguration* lifecycleConfiguration = [SDLLifecycleConfiguration d
 let lifecycleConfiguration = SDLLifecycleConfiguration(appName:"<#App Name#>", appId: "<#App Id#>")
 ```
 
-#### TCP
+**TCP**
 ##### Objective-C
 ```objc
 SDLLifecycleConfiguration* lifecycleConfiguration = [SDLLifecycleConfiguration debugConfigurationWithAppName:@"<#App Name#>" appId:@"<#App Id#>" ipAddress:@"<#IP Address#>" port:<#Port#>];
@@ -270,7 +270,6 @@ SDLLogConfiguration.default()
 
 ### 7. Set the Configuration
 The `SDLConfiguration` class is used to set the lifecycle, lock screen, logging, and optionally (dependent on if you are a Navigation or Projection app) streaming media configurations for the app. Use the lifecycle configuration settings above to instantiate a `SDLConfiguration` instance.
-
 ##### Objective-C
 ```objc
 SDLConfiguration* configuration = [SDLConfiguration configurationWithLifecycle:lifecycleConfiguration lockScreen:[SDLLockScreenConfiguration enabledConfiguration] logging:[SDLLogConfiguration defaultConfiguration]];
@@ -410,7 +409,6 @@ static NSString* const AppId = @"<#App Id#>";
 
 NS_ASSUME_NONNULL_END
 ```
-
 ##### Swift
 ```swift
 import SmartDeviceLink
@@ -482,5 +480,5 @@ In addition there are three optional methods:
 1. `systemContext:didChangeToContext:` Called when the system context (i.e. a menu is open, an alert is visible,  a voice recognition session is in progress) of this application changes on the remote system. For more information, please refer to [Understanding Permissions](Getting Started/Understanding Permissions).
 1. `managerShouldUpdateLifecycleToLanguage:` Called when the head unit language does not match the `language` set in the `SDLLifecycleConfiguration` but does match a language included in `languagesSupported`. If desired, you can customize the `appName`, the `shortAppName`,  and `ttsName` for the head unit's current language. For more information about supporting more than one language in your app please refer to [Getting Started/Adapting to the Head Unit Language](Getting Started/Adapting to the Head Unit Language).
 
-### Where to go from here
+### Where to Go From Here
 You should now be able to connect to a head unit or emulator. From here, [learn about designing a user interface](Displaying Information/Designing a User Interface). For further details on connecting, see [Connecting to a SDL Core](Getting Started/Connecting to a SDL Core).

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -4,10 +4,7 @@ SmartDeviceLink works by sending remote procedure calls (RPCs) back and forth be
 
 ### Set Up a Proxy Manager Class
 You will need a class that manages the RPCs sent back and forth between your app and SDL Core. Since there should be only one active connection to the SDL Core, you may wish to implement this proxy class using the singleton pattern.
-
-
 #### Objective-C
-
 **ProxyManager.h**
 ```objc
 #import <Foundation/Foundation.h>
@@ -99,12 +96,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 ### Import the SDL Library
 At the top of the *ProxyManager* class, import the SDL for iOS library.
-
 #### Objective-C
 ```objc
 #import <SmartDeviceLink/SmartDeviceLink.h>
 ```
-
 #### Swift
 ```swift
 import SmartDeviceLink
@@ -112,7 +107,6 @@ import SmartDeviceLink
 
 ### Create the SDL Manager
 The `SDLManager` is the main class of SmartDeviceLink. It will handle setting up the initial connection with the head unit. It will also help you upload images and send RPCs.
-
 #### Objective-C
 ```objc
 #import "ProxyManager.h"
@@ -151,7 +145,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 ```
-
 #### Swift
 ```swift
 class ProxyManager: NSObject {
@@ -174,23 +167,21 @@ In order to instantiate the `SDLManager` class, you must first configure an `SDL
 There are two different ways to connect your app to a SDL Core: with a TCP (Wi-Fi) network connection or with an iAP (USB / Bluetooth) network connection. Use TCP for debugging and use iAP for production level apps.
 
 #### iAP
-#### Objective-C
+##### Objective-C
 ```objc
 SDLLifecycleConfiguration* lifecycleConfiguration = [SDLLifecycleConfiguration defaultConfigurationWithAppName:@"<#App Name#>" appId:@"<#App Id#>"];
 ```
-
-#### Swift
+##### Swift
 ```swift
 let lifecycleConfiguration = SDLLifecycleConfiguration(appName:"<#App Name#>", appId: "<#App Id#>")
 ```
 
 #### TCP
-#### Objective-C
+##### Objective-C
 ```objc
 SDLLifecycleConfiguration* lifecycleConfiguration = [SDLLifecycleConfiguration debugConfigurationWithAppName:@"<#App Name#>" appId:@"<#App Id#>" ipAddress:@"<#IP Address#>" port:<#Port#>];
 ```
-
-#### Swift
+##### Swift
 ```swift
 let lifecycleConfiguration = SDLLifecycleConfiguration(appName: "<#App Name#>", appId: "<#App Id#>", ipAddress: "<#IP Address#>", port: <#Port#>))
 ```  
@@ -200,27 +191,23 @@ If you are using an emulator, the IP address is your computer or virtual machine
 !!!
 
 !!! IMPORTANT
-If you are using a head unit or TDK, and are using the [relay app](https://github.com/smartdevicelink/relay_app_ios) for debugging, the IP address and port number should be set to the same IP address and port number as the app. This information appears in the relay app once the server is turned on in the relay app. Also be sure that the device is on the same network as your app.
+If you are using a head unit or TDK, and are using the [Relay app](Developer Tools/Relay) for debugging, the IP address and port number should be set to the same IP address and port number as the app. This information appears in the Relay app once the server is turned on in the app. Also be sure that the device is on the same network as your app.
 !!!
-
 
 ### 2. Short app name (optional)
 This is a shortened version of your app name that is substituted when the full app name will not be visible due to character count constraints. You will want to make this as short as possible.
-
-#### Objective-C
+##### Objective-C
 ```objc
 lifecycleConfiguration.shortAppName = @"<#Shortened App Name#>";
 ```
-
-#### Swift
+##### Swift
 ```swift
 lifecycleConfiguration.shortAppName = "<#Shortened App Name#>"
 ```
 
 ### 3. App Icon
 This is a custom icon for your application. Please refer to [Uploading Files and Graphics](Uploading Files and Graphics) for icon sizes.
-
-#### Objective-C
+##### Objective-C
 ```objc
 UIImage* appImage = [UIImage imageNamed:@"<#AppIcon Name#>"];
 if (appImage) {
@@ -228,8 +215,7 @@ if (appImage) {
   lifecycleConfiguration.appIcon = appIcon;  
 }
 ```
-
-#### Swift
+##### Swift
 ```swift
 if let appImage = UIImage(named: "<#AppIcon Name#>") {
   let appIcon = SDLArtwork(image: appImage, name: "<#Name to Upload As#>", persistent: true, as: .JPG /* or .PNG */)
@@ -249,76 +235,67 @@ The app type is used by car manufacturers to decide how to categorize your app. 
 Navigation and projection apps usually require special permissions and use video streaming to project a UI.
 !!!
 
-#### Objective-C
+##### Objective-C
 ```objc
 lifecycleConfiguration.appType = SDLAppHMITypeMedia;
 ```
-
-#### Swift
+##### Swift
 ```swift
 lifecycleConfiguration.appType = .media
 ```
 
-### 2. Lock screen
+### 5. Lock Screen
 A lock screen is used to prevent the user from interacting with the app on the smartphone while they are driving. When the vehicle starts moving, the lock screen is activated. Similarly, when the vehicle stops moving, the lock screen is removed. You must implement a lock screen in your app for safety reasons. Any application without a lock screen will not get approval for release to the public.
 
 The SDL SDK can take care of the lock screen implementation for you, automatically using your app logo and the connected vehicle logo. If you do not want to use the default lock screen, you can implement your own custom lock screen.
 
 For more information, please refer to the [Adding the Lock Screen](Adding the Lock Screen) section, for this guide we will be using `SDLLockScreenConfiguration`'s basic `enabledConfiguration`.
-
-#### Objective-C
+##### Objective-C
 ```objc
 [SDLLockScreenConfiguration enabledConfiguration]
 ```
-
-#### Swift
+##### Swift
 ```swift
 SDLLockScreenConfiguration.enabled()
 ```
 
-### 3. Logging
+### 6. Logging
 A logging configuration is used to define where and how often SDL will log. It will also allow you to set your own logging modules and filters.
-
-#### Objective-C
+##### Objective-C
 ```objc
 [SDLLogConfiguration defaultConfiguration]
 ```
-
-#### Swift
+##### Swift
 ```objc
 SDLLogConfiguration.default()
 ```
 
-### 4. Set the Configuration
+### 7. Set the Configuration
 The `SDLConfiguration` class is used to set the lifecycle, lock screen, logging, and optionally (dependent on if you are a Navigation or Projection app) streaming media configurations for the app. Use the lifecycle configuration settings above to instantiate a `SDLConfiguration` instance.
 
-#### Objective-C
+##### Objective-C
 ```objc
 SDLConfiguration* configuration = [SDLConfiguration configurationWithLifecycle:lifecycleConfiguration lockScreen:[SDLLockScreenConfiguration enabledConfiguration] logging:[SDLLogConfiguration defaultConfiguration]];
 ```
-
-#### Swift
+##### Swift
 ```swift
 let configuration = SDLConfiguration(lifecycle: lifecycleConfiguration, lockScreen: .enabled(), logging: .default())
 ```
 
-### 4. Create a SDLManager
+### 8. Create a SDLManager
 Now you can use the `SDLConfiguration` instance to instantiate the `SDLManager`.
-
-#### Objective-C
+##### Objective-C
 ```objc
 self.sdlManager = [[SDLManager alloc] initWithConfiguration:configuration delegate:self];
 ```
-
-#### Swift**
+##### Swift
 ```swift
 sdlManager = SDLManager(configuration: configuration, delegate: self)
 ```
 
-### 5. Start the SDLManager
+### 9. Start the SDLManager
 The manager should be started as soon as possible in your application's lifecycle. We suggest doing this in the `didFinishLaunchingWithOptions()` method in your *AppDelegate* class. Once the manager has been initialized, it will immediately start watching for a connection with the remote system. The manager will passively search for a connection with a SDL Core during the entire lifespan of the app. If the manager detects a connection with a SDL Core, the `startWithReadyHandler` will be called.
-
-#### Objective-C
+##### Objective-C
 ```objc
 [self.sdlManager startWithReadyHandler:^(BOOL success, NSError * _Nullable error) {
   if (success) {
@@ -326,8 +303,7 @@ The manager should be started as soon as possible in your application's lifecycl
   }
 }];
 ```
-
-#### Swift
+##### Swift
 ```swift
 sdlManager.start { (success, error) in
     if success {
@@ -342,10 +318,9 @@ In production, your app will be watching for connections using iAP, which will n
 
 If the connection is successful, you can start sending RPCs to the SDL Core. However, some RPCs can only be sent when the HMI is in the FULL or LIMITED state. If the SDL Core's HMI is not ready to accept these RPCs, your requests will be ignored. If you want to make sure that the SDL Core will not ignore your RPCs, use the `SDLManagerDelegate` methods in the next section.
 
-### 6. Example Implementation of a Proxy Class  
+### 10. Example Implementation of a Proxy Class  
 The following code snippet has an example of setting up both a TCP and iAP connection.
-
-#### Objective-C
+##### Objective-C
 ProxyManager.h
 ```objc
 #import <Foundation/Foundation.h>
@@ -438,7 +413,7 @@ static NSString* const AppId = @"<#App Id#>";
 NS_ASSUME_NONNULL_END
 ```
 
-#### Swift
+##### Swift
 ```swift
 import SmartDeviceLink
 

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -4,8 +4,8 @@ SmartDeviceLink works by sending remote procedure calls (RPCs) back and forth be
 
 ### Set Up a Proxy Manager Class
 You will need a class that manages the RPCs sent back and forth between your app and SDL Core. Since there should be only one active connection to the SDL Core, you may wish to implement this proxy class using the singleton pattern.
-#### Objective-C
-**ProxyManager.h**
+##### Objective-C
+###### ProxyManager.h
 ```objc
 #import <Foundation/Foundation.h>
 
@@ -19,8 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 ```
-
-**ProxyManager.m**
+###### ProxyManager.m
 ```objc
 #import "ProxyManager.h"
 
@@ -54,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 ```
 
-#### Swift
+##### Swift
 ```swift
 class ProxyManager: NSObject {
   // Singleton
@@ -70,7 +69,7 @@ Your app should always start passively watching for a connection with a SDL Core
 
 The connect method will be implemented later. To see a full example, navigate to the bottom of this page.
 
-#### Objective-C
+##### Objective-C
 ```objc
 @implementation AppDelegate
 
@@ -81,8 +80,7 @@ The connect method will be implemented later. To see a full example, navigate to
 
 @end
 ```
-
-#### Swift
+##### Swift
 ```swift
 class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
@@ -96,18 +94,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 ### Import the SDL Library
 At the top of the *ProxyManager* class, import the SDL for iOS library.
-#### Objective-C
+##### Objective-C
 ```objc
 #import <SmartDeviceLink/SmartDeviceLink.h>
 ```
-#### Swift
+##### Swift
 ```swift
 import SmartDeviceLink
 ```
 
 ### Create the SDL Manager
 The `SDLManager` is the main class of SmartDeviceLink. It will handle setting up the initial connection with the head unit. It will also help you upload images and send RPCs.
-#### Objective-C
+##### Objective-C
 ```objc
 #import "ProxyManager.h"
 #import "SmartDeviceLink.h"
@@ -145,7 +143,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 ```
-#### Swift
+##### Swift
 ```swift
 class ProxyManager: NSObject {
   // Manager
@@ -321,7 +319,7 @@ If the connection is successful, you can start sending RPCs to the SDL Core. How
 ### 10. Example Implementation of a Proxy Class  
 The following code snippet has an example of setting up both a TCP and iAP connection.
 ##### Objective-C
-ProxyManager.h
+**ProxyManager.h**
 ```objc
 #import <Foundation/Foundation.h>
 
@@ -337,7 +335,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 ```
 
-ProxyManager.m
+**ProxyManager.m**
 ```objc
 #import <SmartDeviceLink/SmartDeviceLink.h>
 

--- a/docs/Getting Started/Integration Basics/index.md
+++ b/docs/Getting Started/Integration Basics/index.md
@@ -315,10 +315,10 @@ In production, your app will be watching for connections using iAP, which will n
 
 If the connection is successful, you can start sending RPCs to the SDL Core. However, some RPCs can only be sent when the HMI is in the FULL or LIMITED state. If the SDL Core's HMI is not ready to accept these RPCs, your requests will be ignored. If you want to make sure that the SDL Core will not ignore your RPCs, use the `SDLManagerDelegate` methods in the next section.
 
-### 10. Example Implementation of a Proxy Class  
+### Example Implementation of a Proxy Class  
 The following code snippet has an example of setting up both a TCP and iAP connection.
 ##### Objective-C
-**ProxyManager.h**
+###### ProxyManager.h
 ```objc
 #import <Foundation/Foundation.h>
 
@@ -334,7 +334,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 ```
 
-**ProxyManager.m**
+###### ProxyManager.m 
 ```objc
 #import <SmartDeviceLink/SmartDeviceLink.h>
 

--- a/docs/Getting Started/Understanding Permissions/index.md
+++ b/docs/Getting Started/Understanding Permissions/index.md
@@ -1,5 +1,6 @@
 ## Understanding Permissions
 While you are creating your SDL app, you must remember that just because your app is connected to a head unit it doesn't necessary mean that your app has the required permissions to send RPCs to the head unit. There are three important things to remember regarding permissions:
+
 1. You may not be able to send a RPC when the SDL app is closed, in the background, or obscured by a system alert. Each RPC is assigned a set of `hmiLevel`s when it is allowed to be sent.
 1. For some RPCs, like those that access vehicle data or make a phone call, you may need special permissions from the OEM to use. This permission is granted when you submit your app to the OEM for approval. Each OEM decides which RPCs it will restrict access to, so it is up you to check if you are allowed to use the RPC with the head unit.
 1. Some head units may not support all RPCs.
@@ -8,7 +9,7 @@ While you are creating your SDL app, you must remember that just because your ap
 ### HMI Levels
 When your app is connected to the head unit you will receive notifications when the SDL app's HMI status changes. Your app can be in one of four different `hmiLevel`s:
 
-HMI Level   | The App's UI Status
+HMI Level   | What does this mean?
 ------------|------------------------------------------------------------
 NONE        | The user has not yet opened your app, or the app has been killed.
 BACKGROUND  | The user has opened your app, but is currently in another part of the head unit.

--- a/docs/Getting Started/Understanding Permissions/index.md
+++ b/docs/Getting Started/Understanding Permissions/index.md
@@ -5,7 +5,6 @@ While creating your SDL app, remember that just because your app is connected to
 1. For some RPCs, like those that access vehicle data or make a phone call, you may need special permissions from the OEM to use. This permission is granted when you submit your app to the OEM for approval. Each OEM decides which RPCs it will restrict access to, so it is up you to check if you are allowed to use the RPC with the head unit.
 1. Some head units may not support all RPCs.
 
-
 ### HMI Levels
 When your app is connected to the head unit you will receive notifications when the SDL app's HMI status changes. Your app can be in one of four different `hmiLevel`s:
 
@@ -18,10 +17,9 @@ FULL        | Your app is currently in focus on the screen.
 
 Be careful with sending user interface related RPCs in the `NONE` and `BACKGROUND` levels; some head units may reject RPCs sent in those states. We recommended that you wait until your app's `hmiLevel` enters `FULL` to set up your app's UI.
 
-### Monitoring the HMI Level
+#### Monitoring the HMI Level
 The easiest way to monitor the `hmiLevel` of your SDL app is through a required delegate callback of `SDLManagerDelegate`. The function `hmiLevel:didChangeToLevel:` is called every time your app's `hmiLevel` changes.
-
-#### Objective-C
+##### Objective-C
 ```objc
 - (void)hmiLevel:(SDLHMILevel)oldLevel didChangeToLevel:(SDLHMILevel)newLevel {
     if (![newLevel isEqualToEnum:SDLHMILevelNone] && (self.firstHMILevel == SDLHMIFirstStateNone)) {
@@ -41,8 +39,7 @@ The easiest way to monitor the `hmiLevel` of your SDL app is through a required 
     }
 }
 ```
-
-#### Swift
+##### Swift
 ```swift
 fileprivate var firstHMILevel: SDLHMILevel = .none
 func hmiLevel(_ oldLevel: SDLHMILevel, didChangeToLevel newLevel: SDLHMILevel) {
@@ -103,7 +100,7 @@ let observerId = sdlManager.permissionManager.addObserver(forRPCs: <#RPC name#>,
 })
 ```
 
-#### Stop Observing Permissions**
+#### Stop Observing Permissions
 When you set up the observer, you will get an unique id back. Use this id to unsubscribe to the permissions at a later date.
 ##### Objective-C
 ```objc
@@ -128,14 +125,13 @@ AUDIBLE     			| Any audio you are streaming will be audible to the user.
 ATTENUATED  			| Some kind of audio mixing is occuring between what you are streaming, if anything, and some system level sound. This can be visible is displaying an Alert with `playTone` set to `true`.
 NOT_AUDIBLE 			| Your streaming audio is not audible. This could occur during a VRSESSSION System Context.
 
-#### Objective-C
+##### Objective-C
 ```objc
 - (void)audioStreamingState:(nullable SDLAudioStreamingState)oldState didChangeToState:(SDLAudioStreamingState)newState {
     <#code#>
 }
 ```
-
-#### Swift
+##### Swift
 ```swift
 func audioStreamingState(_ oldState: SDLAudioStreamingState?, didChangeToState newState: SDLAudioStreamingState) {
     <#code#>
@@ -153,14 +149,14 @@ MENU     			   | A menu interaction is currently in-progress.
 HMI_OBSCURED    	   | The app's display HMI is being blocked by either a system or other app's overlay (another app's Alert, for instance).
 ALERT 				   | An alert that you have sent is currently visible.
 
-#### Objective-C
+##### Objective-C
 ```objc
 - (void)systemContext:(nullable SDLSystemContext)oldContext didChangeToContext:(SDLSystemContext)newContext {
     <#code#>
 }
 ```
 
-#### Swift
+##### Swift
 ```swift
 func systemContext(_ oldContext: SDLSystemContext?, didChangeToContext newContext: SDLSystemContext) {
     <#code#>

--- a/docs/Getting Started/Understanding Permissions/index.md
+++ b/docs/Getting Started/Understanding Permissions/index.md
@@ -1,34 +1,75 @@
-## Knowing the In-Car UI Status
-Once your app is connected to Core, most of the interaction you will be doing requires knowledge of the current In-Car UI, or HMI, Status. For a refresher on how to get your app integrated with SDL, and to connect to Core, head to [Getting Started > Integration Basics](Getting Started/Integration Basics). The HMI Status informs you of where the user is within the head unit in a general sense. 
+## Understanding Permissions
+While you are creating your SDL app, you must remember that just because your app is connected to a head unit, it doesn't necessary mean that your app has the required permissions to send RPCs to the head unit. There are two important things to remember regarding permissions:
+1. You might not be able to send an RPC when the SDL app is closed or when the main screen is obscured by a menu or alert. Each RPC has a set of `hmiLevel`s that restricts when it can be sent.
+1. Some RPCs need special permissions from the OEM in order to be sent. Each OEM decides which RPCs it will restrict so it is up to the developer to check if they have the correct permissions. 
 
-Refer to the table below of all possible HMI States:
 
-HMI State   | What does this mean?
+### HMI Levels
+Once your app is connected to the head unit, you will receive notifications when the SDL app's HMI status changes. Your SDL app can be in one of four different `hmiLevel`s:
+
+HMI Level   | The Head Unit's UI Status
 ------------|------------------------------------------------------------
 NONE        | The user has not been opened your app, or it has been Exited via the "Menu" button.
 BACKGROUND  | The user has opened your app, but is currently in another part of the Head Unit. If you have a Media app, this means that another Media app has been selected.
 LIMITED     | For Media apps, this means that a user has opened your app, but is in another part of the Head Unit.
 FULL        | Your app is currently in focus on the screen.
 
-!!! NOTE
-Be careful with sending RPCs in the NONE and BACKGROUND states; some head units may limit the number of RPCs you may send in these states before blocking your requests. It is recommended that you wait until your app reaches HMI FULL to set up your app UI.
-!!!
+Be careful with sending UI related RPCs in the `NONE` and `BACKGROUND` states; some head units may reject RPCs sent in those states. We recommended that you wait until your app's `hmiLevel` enters `FULL` to set up your app's UI.
 
-### Monitoring HMI Status
-Monitoring HMI Status is provided through a required delegate callback of `SDLManagerDelegate`. The function `hmiLevel:didChangeToLevel:` will give you information relating the previous and new HMI levels your app is progressing through.
+### Monitoring the HMI Level
+The easiest way to monitor the `hmiLevel` of your SDL app is through a required delegate callback of `SDLManagerDelegate`. The function `hmiLevel:didChangeToLevel:` is called every time your app's `hmiLevel` changes.
 
 #### Objective-C
 ```objc
-- (void)hmiLevel:(SDLHMILevel *)hmiLevel didChangeToNewLevel:(SDLHMILevel *)newLevel {
-    <# code #>
+- (void)hmiLevel:(SDLHMILevel)oldLevel didChangeToLevel:(SDLHMILevel)newLevel {
+    if (![newLevel isEqualToEnum:SDLHMILevelNone] && (self.firstHMILevel == SDLHMIFirstStateNone)) {
+        // This is our first time in a non-`NONE` state
+        self.firstHMILevel = newLevel;
+        <#Send static menu RPCs#>
+    }
+
+    if ([newLevel isEqualToEnum:SDLHMILevelFull]) {
+        <#Send user interface RPCs#>
+    } else if ([newLevel isEqualToEnum:SDLHMILevelLimited]) {
+        <#Code#>
+    } else if ([newLevel isEqualToEnum:SDLHMILevelBackground]) {
+        <#Code#>
+    } else if ([newLevel isEqualToEnum:SDLHMILevelNone]) {
+        <#Code#>
+    }
 }
 ```
 
 #### Swift
 ```swift
+fileprivate var firstHMILevel: SDLHMILevel = .none
 func hmiLevel(_ oldLevel: SDLHMILevel, didChangeToLevel newLevel: SDLHMILevel) {
-    <# code #>
+    if newLevel != .none && firstHMILevel == .none {
+        // This is our first time in a non-`NONE` state
+        firstHMILevel = newLevel
+        <#Send static menu RPCs#>
+    }
+
+    switch newLevel {
+    case .full:
+        <#Send user interface RPCs#>
+    case .limited: break 
+    case .background: break
+    case .none: break
+    default: break
+    }
 }
+```
+
+### Permission Manager
+In addition to monitoring the `hmiLevel`, you can check the current permission status of a specific RPC or group of RPCs. If desired, you may also subscribe to get notifications when the permission status changes for a RPC or group of RPCs. 
+
+#### Objective-C
+```objc
+```
+
+#### Swift
+```swift
 ```
 
 ### More Detailed HMI Information

--- a/docs/Getting Started/Understanding Permissions/index.md
+++ b/docs/Getting Started/Understanding Permissions/index.md
@@ -66,56 +66,50 @@ func hmiLevel(_ oldLevel: SDLHMILevel, didChangeToLevel newLevel: SDLHMILevel) {
 ### Permission Manager
 When your app first connects to the head unit, it will receive an `OnPermissionsChange` notification. This notification contains all RPCs the head unit supports and the `hmiLevel` permissions for each RPC. Use the `SDLManager`'s permission manager to check the current permission status of a specific RPC or group of RPCs. If desired, you may also subscribe to get notifications when the RPC(s) permission status changes. 
 
-**Check Current Permissions of a Single RPC**
-#### Objective-C
+#### Check Current Permissions of a Single RPC
+##### Objective-C
 ```objc
 BOOL isAllowed = [self.sdlManager.permissionManager isRPCAllowed:<#RPC name#>];
 ```
-
-#### Swift
+##### Swift
 ```swift
 let isAllowed = sdlManager.permissionManager.isRPCAllowed(<#RPC name#>)
 ```
 
-**Check Current Permissions of a Group of RPCs**
-#### Objective-C
+#### Check Current Permissions of a Group of RPCs
+##### Objective-C
 ```objc
 SDLPermissionGroupStatus groupPermissionStatus = [self.sdlManager.permissionManager groupStatusOfRPCs:@[<#RPC name#>, <#RPC name#>]rpcGroup];
 NSDictionary *individualPermissionStatuses = [self.sdlManager.permissionManager statusOfRPCs:@[<#RPC name#>, <#RPC name#>]];
 ```
-
-#### Swift
+##### Swift
 ```swift
 let groupPermissionStatus = sdlManager.permissionManager.groupStatus(ofRPCs:[<#RPC name#>, <#RPC name#>])
 let individualPermissionStatuses = sdlManager.permissionManager.status(ofRPCs:[<#RPC name#>, <#RPC name#>])
 ```
 
-**Observe Permissions**
+#### Observe Permissions
 If desired, you can set an observer for a group of permissions. The observer's handler will be called when the permissions for the group changes. If you want to be notified when the permission status of any of RPCs in the group change, set the `groupType` to `SDLPermissionGroupTypeAny`. If you only want to be notified when all of the RPCs in the group are allowed or not allowed, set the `groupType` to `SDLPermissionGroupTypeAllAllowed`.
-
-#### Objective-C
+##### Objective-C
 ```objc
 SDLPermissionObserverIdentifier observerId = [self.sdlManager.permissionManager addObserverForRPCs:@[<#RPC name#>, <#RPC name#>] groupType:<#SDLPermissionGroupType#> withHandler:^(NSDictionary<SDLPermissionRPCName, NSNumber<SDLBool> *> * _Nonnull change, SDLPermissionGroupStatus status) {
     <#RPC group status changed#>
 }];
 ```
-
-#### Swift
+##### Swift
 ```swift
 let observerId = sdlManager.permissionManager.addObserver(forRPCs: <#RPC name#>, <#RPC name#>, groupType:<#SDLPermissionGroupType#>, withHandler: { (individualStatuses, groupStatus) in
     <#RPC group status changed#>
 })
 ```
 
-**Stop Observing Permissions**
+#### Stop Observing Permissions**
 When you set up the observer, you will get an unique id back. Use this id to unsubscribe to the permissions at a later date.
-
-#### Objective-C
+##### Objective-C
 ```objc
 [self.sdlManager.permissionManager removeObserverForIdentifier:observerId];
 ```
-
-#### Swift
+##### Swift
 ```swift
 sdlManager.permissionManager.removeObserver(forIdentifier: observerId)
 ```

--- a/docs/Getting Started/Understanding Permissions/index.md
+++ b/docs/Getting Started/Understanding Permissions/index.md
@@ -12,7 +12,7 @@ HMI Level   | What does this mean?
 ------------|------------------------------------------------------------
 NONE        | The user has not yet opened your app, or the app has been killed.
 BACKGROUND  | The user has opened your app, but is currently in another part of the head unit.
-LIMITED     | This level only applies to media apps (i.e. apps with an `appType` of `media`). The user has opened your app, but is currently in another part of the head unit. The app can receive button presses from the play, seek, tune, and preset buttons.
+LIMITED     | This level only applies to media and navigation apps (i.e. apps with an `appType` of `MEDIA` or `NAVIGATION`). The user has opened your app, but is currently in another part of the head unit. The app can receive button presses from the play, seek, tune, and preset buttons.
 FULL        | Your app is currently in focus on the screen.
 
 Be careful with sending user interface related RPCs in the `NONE` and `BACKGROUND` levels; some head units may reject RPCs sent in those states. We recommended that you wait until your app's `hmiLevel` enters `FULL` to set up your app's UI.

--- a/docs/Getting Started/Understanding Permissions/index.md
+++ b/docs/Getting Started/Understanding Permissions/index.md
@@ -118,13 +118,13 @@ When you set up the observer, you will get an unique id back. Use this id to uns
 sdlManager.permissionManager.removeObserver(forIdentifier: observerId)
 ```
 
-### More Detailed HMI Information
-When an interaction occurs relating to your application, there is some additional pieces of information that can be observed that help figure out a more descriptive picture of what is going on with the Head Unit.
+### Additional HMI State Information
+If you want more detail about the current state of your SDL app, you can also monitor the audio streaming state and get notifications when something blocks the main screen of your app.
 
 #### Audio Streaming State
-The Audio Streaming State informs your app whether any currently streaming audio is audible to user (AUDIBLE) or not (NOT_AUDIBLE). A value of NOT_AUDIBLE means that either the application's audio will not be audible to the user, or that the application's audio should not be audible to the user (i.e. some other application on the mobile device may be streaming audio and the application's audio would be blended with that other audio).
+The Audio Streaming State informs your app whether any currently streaming audio is audible to user (`AUDIBLE`) or not (`NOT_AUDIBLE`). A value of `NOT_AUDIBLE` means that either the application's audio will not be audible to the user, or that the application's audio should not be audible to the user (i.e. some other application on the mobile device may be streaming audio and the application's audio would be blended with that other audio).
 
-You will see this come in for things such as Alert, PerformAudioPassThru, Speaks, etc.
+You will get these notifications when an alert pops up, when you start recording the in-car audio, when voice recognition is active, etc.
 
 Audio Streaming State   | What does this mean?
 ------------------------|------------------------------------------------------------
@@ -135,19 +135,19 @@ NOT_AUDIBLE 			| Your streaming audio is not audible. This could occur during a 
 #### Objective-C
 ```objc
 - (void)audioStreamingState:(nullable SDLAudioStreamingState)oldState didChangeToState:(SDLAudioStreamingState)newState {
-    <# code #>
+    <#code#>
 }
 ```
 
 #### Swift
 ```swift
 func audioStreamingState(_ oldState: SDLAudioStreamingState?, didChangeToState newState: SDLAudioStreamingState) {
-    <# code #>
+    <#code#>
 }
 ```
 
 #### System Context
-System Context informs your app if there is potentially a blocking HMI component while your app is still visible. An example of this would be if your application is open, and you display an Alert. Your app will receive a System Context of ALERT while it is presented on the screen, followed by MAIN when it is dismissed.
+System Context informs your app if there is potentially a blocking HMI component while your app is still visible. An example of this would be if your application is open and you display an Alert. Your app will receive a System Context of `ALERT` while it is presented on the screen, followed by `MAIN` when it is dismissed.
 
 System Context State   | What does this mean?
 -----------------------|------------------------------------------------------------
@@ -155,18 +155,18 @@ MAIN        		   | No user interaction is in progress that could be blocking you
 VRSESSION  			   | Voice Recognition is currently in progress.
 MENU     			   | A menu interaction is currently in-progress. 
 HMI_OBSCURED    	   | The app's display HMI is being blocked by either a system or other app's overlay (another app's Alert, for instance).
-ALERT 				   | An alert that you have sent is currently visible (Other apps will not receive this).
+ALERT 				   | An alert that you have sent is currently visible.
 
 #### Objective-C
 ```objc
 - (void)systemContext:(nullable SDLSystemContext)oldContext didChangeToContext:(SDLSystemContext)newContext {
-    <# code #>
+    <#code#>
 }
 ```
 
 #### Swift
 ```swift
 func systemContext(_ oldContext: SDLSystemContext?, didChangeToContext newContext: SDLSystemContext) {
-    <# code #>
+    <#code#>
 }
 ```

--- a/docs/Getting Started/Understanding Permissions/index.md
+++ b/docs/Getting Started/Understanding Permissions/index.md
@@ -1,20 +1,21 @@
 ## Understanding Permissions
-While you are creating your SDL app, you must remember that just because your app is connected to a head unit, it doesn't necessary mean that your app has the required permissions to send RPCs to the head unit. There are two important things to remember regarding permissions:
-1. You might not be able to send an RPC when the SDL app is closed or when the main screen is obscured by a menu or alert. Each RPC has a set of `hmiLevel`s that restricts when it can be sent.
-1. Some RPCs need special permissions from the OEM in order to be sent. Each OEM decides which RPCs it will restrict so it is up to the developer to check if they have the correct permissions. 
+While you are creating your SDL app, you must remember that just because your app is connected to a head unit it doesn't necessary mean that your app has the required permissions to send RPCs to the head unit. There are three important things to remember regarding permissions:
+1. You may not be able to send a RPC when the SDL app is closed, in the background, or obscured by a system alert. Each RPC is assigned a set of `hmiLevel`s when it is allowed to be sent.
+1. For some RPCs, like those that access vehicle data or make a phone call, you may need special permissions from the OEM to use. This permission is granted when you submit your app to the OEM for approval. Each OEM decides which RPCs it will restrict access to, so it is up you to check if you are allowed to use the RPC with the head unit.
+1. Some head units may not support all RPCs.
 
 
 ### HMI Levels
-Once your app is connected to the head unit, you will receive notifications when the SDL app's HMI status changes. Your SDL app can be in one of four different `hmiLevel`s:
+When your app is connected to the head unit you will receive notifications when the SDL app's HMI status changes. Your app can be in one of four different `hmiLevel`s:
 
-HMI Level   | The Head Unit's UI Status
+HMI Level   | The App's UI Status
 ------------|------------------------------------------------------------
-NONE        | The user has not been opened your app, or it has been Exited via the "Menu" button.
-BACKGROUND  | The user has opened your app, but is currently in another part of the Head Unit. If you have a Media app, this means that another Media app has been selected.
-LIMITED     | For Media apps, this means that a user has opened your app, but is in another part of the Head Unit.
+NONE        | The user has not yet opened your app, or the app has been killed.
+BACKGROUND  | The user has opened your app, but is currently in another part of the head unit.
+LIMITED     | A user has opened your app, but the main screen is obscured by a message or an alert.
 FULL        | Your app is currently in focus on the screen.
 
-Be careful with sending UI related RPCs in the `NONE` and `BACKGROUND` states; some head units may reject RPCs sent in those states. We recommended that you wait until your app's `hmiLevel` enters `FULL` to set up your app's UI.
+Be careful with sending user interface related RPCs in the `NONE` and `BACKGROUND` levels; some head units may reject RPCs sent in those states. We recommended that you wait until your app's `hmiLevel` enters `FULL` to set up your app's UI.
 
 ### Monitoring the HMI Level
 The easiest way to monitor the `hmiLevel` of your SDL app is through a required delegate callback of `SDLManagerDelegate`. The function `hmiLevel:didChangeToLevel:` is called every time your app's `hmiLevel` changes.
@@ -62,14 +63,59 @@ func hmiLevel(_ oldLevel: SDLHMILevel, didChangeToLevel newLevel: SDLHMILevel) {
 ```
 
 ### Permission Manager
-In addition to monitoring the `hmiLevel`, you can check the current permission status of a specific RPC or group of RPCs. If desired, you may also subscribe to get notifications when the permission status changes for a RPC or group of RPCs. 
+When your app first connects to the head unit, it will receive an `OnPermissionsChange` notification. This notification contains all RPCs the head unit supports and the `hmiLevel` permissions for each RPC. Use the `SDLManager`'s permission manager to check the current permission status of a specific RPC or group of RPCs. If desired, you may also subscribe to get notifications when the RPC(s) permission status changes. 
 
+#### Check Current Permissions of a Single RPC
 #### Objective-C
 ```objc
+BOOL isAllowed = [self.sdlManager.permissionManager isRPCAllowed:<#RPC name#>];
 ```
 
 #### Swift
 ```swift
+let isAllowed = sdlManager.permissionManager.isRPCAllowed(<#RPC name#>)
+```
+
+#### Check Current Permissions of a Group of RPCs
+#### Objective-C
+```objc
+SDLPermissionGroupStatus groupPermissionStatus = [self.sdlManager.permissionManager groupStatusOfRPCs:@[<#RPC name#>, <#RPC name#>]rpcGroup];
+NSDictionary *individualPermissionStatuses = [self.sdlManager.permissionManager statusOfRPCs:@[<#RPC name#>, <#RPC name#>]];
+```
+
+#### Swift
+```swift
+let groupPermissionStatus = sdlManager.permissionManager.groupStatus(ofRPCs:[<#RPC name#>, <#RPC name#>])
+let individualPermissionStatuses = sdlManager.permissionManager.status(ofRPCs:[<#RPC name#>, <#RPC name#>])
+```
+
+#### Observe Permissions
+If desired, you can set an observer for a group of permissions. The observer's handler will be called when the permissions for the group changes. If you want to be notified when the permission status of any of RPCs in the group change, set the `groupType` to `SDLPermissionGroupTypeAny`. If you only want to be notified when all of the RPCs in the group are allowed or not allowed, set the `groupType` to `SDLPermissionGroupTypeAllAllowed`.
+
+#### Objective-C
+```objc
+SDLPermissionObserverIdentifier observerId = [self.sdlManager.permissionManager addObserverForRPCs:@[<#RPC name#>, <#RPC name#>] groupType:<#SDLPermissionGroupType#> withHandler:^(NSDictionary<SDLPermissionRPCName, NSNumber<SDLBool> *> * _Nonnull change, SDLPermissionGroupStatus status) {
+    <#RPC group status changed#>
+}];
+```
+
+#### Swift
+```swift
+let observerId = sdlManager.permissionManager.addObserver(forRPCs: <#RPC name#>, <#RPC name#>, groupType:<#SDLPermissionGroupType#>, withHandler: { (individualStatuses, groupStatus) in
+    <#RPC group status changed#>
+})
+```
+
+#### Stop Observing Permissions
+When you set up the observer, you will get an unique id back. Use this id to unsubscribe to the permissions at a later date.
+#### Objective-C
+```objc
+[self.sdlManager.permissionManager removeObserverForIdentifier:observerId];
+```
+
+#### Swift
+```swift
+sdlManager.permissionManager.removeObserver(forIdentifier: observerId)
 ```
 
 ### More Detailed HMI Information

--- a/docs/Getting Started/Understanding Permissions/index.md
+++ b/docs/Getting Started/Understanding Permissions/index.md
@@ -12,10 +12,12 @@ HMI Level   | What does this mean?
 ------------|------------------------------------------------------------
 NONE        | The user has not yet opened your app, or the app has been killed.
 BACKGROUND  | The user has opened your app, but is currently in another part of the head unit.
-LIMITED     | A user has opened your app, but the main screen is obscured by a message or an alert.
+LIMITED     | A user has opened your app, but the main screen is obscured by a menu or an alert.
 FULL        | Your app is currently in focus on the screen.
 
 Be careful with sending user interface related RPCs in the `NONE` and `BACKGROUND` levels; some head units may reject RPCs sent in those states. We recommended that you wait until your app's `hmiLevel` enters `FULL` to set up your app's UI.
+
+To get more detailed information about what state your SDL app is in, check the system context. You can find more information about the system context below.
 
 #### Monitoring the HMI Level
 The easiest way to monitor the `hmiLevel` of your SDL app is through a required delegate callback of `SDLManagerDelegate`. The function `hmiLevel:didChangeToLevel:` is called every time your app's `hmiLevel` changes.

--- a/docs/Getting Started/Understanding Permissions/index.md
+++ b/docs/Getting Started/Understanding Permissions/index.md
@@ -1,7 +1,7 @@
 ## Understanding Permissions
-While you are creating your SDL app, you must remember that just because your app is connected to a head unit it doesn't necessary mean that your app has the required permissions to send RPCs to the head unit. There are three important things to remember regarding permissions:
+While creating your SDL app, remember that just because your app is connected to a head unit it does not mean that the app has permission to send RPCs. If your app does not have the required permissions, the RPC will be rejected. There are three important things to remember in regards to permissions:
 
-1. You may not be able to send a RPC when the SDL app is closed, in the background, or obscured by a system alert. Each RPC is assigned a set of `hmiLevel`s when it is allowed to be sent.
+1. You may not be able to send a RPC when the SDL app is closed, in the background, or obscured by an alert. Each RPC has a set of `hmiLevel`s when it can be sent.
 1. For some RPCs, like those that access vehicle data or make a phone call, you may need special permissions from the OEM to use. This permission is granted when you submit your app to the OEM for approval. Each OEM decides which RPCs it will restrict access to, so it is up you to check if you are allowed to use the RPC with the head unit.
 1. Some head units may not support all RPCs.
 
@@ -66,7 +66,7 @@ func hmiLevel(_ oldLevel: SDLHMILevel, didChangeToLevel newLevel: SDLHMILevel) {
 ### Permission Manager
 When your app first connects to the head unit, it will receive an `OnPermissionsChange` notification. This notification contains all RPCs the head unit supports and the `hmiLevel` permissions for each RPC. Use the `SDLManager`'s permission manager to check the current permission status of a specific RPC or group of RPCs. If desired, you may also subscribe to get notifications when the RPC(s) permission status changes. 
 
-#### Check Current Permissions of a Single RPC
+**Check Current Permissions of a Single RPC**
 #### Objective-C
 ```objc
 BOOL isAllowed = [self.sdlManager.permissionManager isRPCAllowed:<#RPC name#>];
@@ -77,7 +77,7 @@ BOOL isAllowed = [self.sdlManager.permissionManager isRPCAllowed:<#RPC name#>];
 let isAllowed = sdlManager.permissionManager.isRPCAllowed(<#RPC name#>)
 ```
 
-#### Check Current Permissions of a Group of RPCs
+**Check Current Permissions of a Group of RPCs**
 #### Objective-C
 ```objc
 SDLPermissionGroupStatus groupPermissionStatus = [self.sdlManager.permissionManager groupStatusOfRPCs:@[<#RPC name#>, <#RPC name#>]rpcGroup];
@@ -90,7 +90,7 @@ let groupPermissionStatus = sdlManager.permissionManager.groupStatus(ofRPCs:[<#R
 let individualPermissionStatuses = sdlManager.permissionManager.status(ofRPCs:[<#RPC name#>, <#RPC name#>])
 ```
 
-#### Observe Permissions
+**Observe Permissions**
 If desired, you can set an observer for a group of permissions. The observer's handler will be called when the permissions for the group changes. If you want to be notified when the permission status of any of RPCs in the group change, set the `groupType` to `SDLPermissionGroupTypeAny`. If you only want to be notified when all of the RPCs in the group are allowed or not allowed, set the `groupType` to `SDLPermissionGroupTypeAllAllowed`.
 
 #### Objective-C
@@ -107,8 +107,9 @@ let observerId = sdlManager.permissionManager.addObserver(forRPCs: <#RPC name#>,
 })
 ```
 
-#### Stop Observing Permissions
+**Stop Observing Permissions**
 When you set up the observer, you will get an unique id back. Use this id to unsubscribe to the permissions at a later date.
+
 #### Objective-C
 ```objc
 [self.sdlManager.permissionManager removeObserverForIdentifier:observerId];
@@ -120,7 +121,7 @@ sdlManager.permissionManager.removeObserver(forIdentifier: observerId)
 ```
 
 ### Additional HMI State Information
-If you want more detail about the current state of your SDL app, you can also monitor the audio streaming state and get notifications when something blocks the main screen of your app.
+If you want more detail about the current state of your SDL app you can monitor the audio streaming state as well as get notifications when something blocks the main screen of your app.
 
 #### Audio Streaming State
 The Audio Streaming State informs your app whether any currently streaming audio is audible to user (`AUDIBLE`) or not (`NOT_AUDIBLE`). A value of `NOT_AUDIBLE` means that either the application's audio will not be audible to the user, or that the application's audio should not be audible to the user (i.e. some other application on the mobile device may be streaming audio and the application's audio would be blended with that other audio).


### PR DESCRIPTION
Fixes #80

This pull request **adds new content**.

## Summary of Changes
* Added information about the permissions needed to send a RPC successfully. Also added section and code samples for the permission manager Renamed the section to **Understanding Permissions** and relocated it to the **Getting Started** section.
* Fixed numbering issues in the **Integration Basics** section. Also fixed header formatting. 
* Fixed links in the **Integration Basics** that linked to the old **Understanding Permissions** section.