### PR TITLE
Fix remote control notification name

### DIFF
--- a/docs/Other SDL Features/Remote Control Vehicle Features/index.md
+++ b/docs/Other SDL Features/Remote Control Vehicle Features/index.md
@@ -243,7 +243,7 @@ SDLGetInteriorVehicleData *getInteriorVehicleData = [[SDLGetInteriorVehicleData 
 
 ##### Swift
 ```swift
-NotificationCenter.default.addObserver(forName: .SDLDidReceiveInteriorVehicleDataNotification, object: nil, queue: OperationQueue.main) { (notification) in
+NotificationCenter.default.addObserver(forName: .SDLDidReceiveInteriorVehicleData, object: nil, queue: OperationQueue.main) { (notification) in
     guard let dataNotification = notification as? SDLRPCNotificationNotification,
         let onInteriorVehicleData = dataNotification.notification as? SDLOnInteriorVehicleData else { return }
     // This block will now be called whenever vehicle data changes


### PR DESCRIPTION
Fixes #137 

This pull request fixes existing content.

## Summary of Changes
Fixed the name of a notification in swift.